### PR TITLE
Fix: prevent double edit/add modal 

### DIFF
--- a/src/components/addCardModal/addCardModal.component.tsx
+++ b/src/components/addCardModal/addCardModal.component.tsx
@@ -16,6 +16,7 @@ import Tag from "../tag/tag.component";
 import {
   useAddCard,
   useToggleIsAdding,
+  useToggleIsEditing,
   useUpdateCard,
 } from "../../stores/cardStore";
 
@@ -38,13 +39,13 @@ const AddCardModal = ({
   const [isinvalidContent, setIsInvalidContent] = useState<boolean>(false);
 
   const toggleIsAdding = useToggleIsAdding();
+  const toggleIsEditing = useToggleIsEditing();
   const updateCard = useUpdateCard();
   const addNewCard = useAddCard();
 
   const inputRef = useRef<HTMLDivElement>(null);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    console.log("handleSubmit called");
     e.preventDefault();
     submitContent();
   };
@@ -78,7 +79,9 @@ const AddCardModal = ({
       addNewCard(newCard);
     }
     setCurrentContent("");
-    toggleIsAdding();
+    if (card) {
+      toggleIsEditing();
+    } else toggleIsAdding();
   };
 
   useEffect(() => {
@@ -124,7 +127,6 @@ const AddCardModal = ({
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
-            console.log("Enter key pressed, submitting form");
             const fakeSubmitEvent = {
               preventDefault: () => {},
             } as unknown as React.FormEvent<HTMLFormElement>;

--- a/src/components/board/board.component.tsx
+++ b/src/components/board/board.component.tsx
@@ -6,15 +6,17 @@ import AddCardModal from "../addCardModal/addCardModal.component";
 import Tag from "../tag/tag.component";
 import { CardType } from "../../types/card";
 import { CARD_TAGS } from "../../constants/tags";
+import { useIsEditing, useToggleIsEditing } from "../../stores/cardStore";
 
 export const Board = ({ cards }: { cards: CardType[] }) => {
-  const [isEditing, setIsEditing] = useState(false);
   const [editingCard, setEditingCard] = useState<CardType | null>(null);
   const [tagFilter, setTagFilter] = useState<string>("");
   const [renderedCards, setRenderedCards] = useState<CardType[]>(cards);
 
+  const toggleIsEditing = useToggleIsEditing();
+
   const editCard = (card: CardType) => {
-    setIsEditing(true);
+    toggleIsEditing();
     setEditingCard(card);
   };
 
@@ -54,7 +56,7 @@ export const Board = ({ cards }: { cards: CardType[] }) => {
         ) : (
           <Placeholder>Try adding some cards</Placeholder>
         )}
-        {isEditing && editingCard && <AddCardModal card={editingCard} />}
+        {useIsEditing() && editingCard && <AddCardModal card={editingCard} />}
       </BoardContainer>
     </>
   );

--- a/src/stores/cardStore.ts
+++ b/src/stores/cardStore.ts
@@ -21,13 +21,14 @@ interface CardState {
     deleteCard: (id: string) => void;
     updateCard: (id: string, updatedCard: Partial<Card>) => void;
     isAdding: boolean;
+    isEditing: boolean;
     toggleIsAdding: () => void;
+    toggleIsEditing: () => void;
 }
 
 const useCardStore = create<CardState>((set) => ({
     cards: [],
     setCards: (cards) => {
-        console.log("Setting cards:", cards);
         localStorage.setItem("cards", JSON.stringify(cards));
         set({ cards })
     },
@@ -57,7 +58,9 @@ const useCardStore = create<CardState>((set) => ({
         cards: updatedCards
     }}),
     isAdding: false,
+    isEditing: false,
     toggleIsAdding: () => set((state) => ({ isAdding: !state.isAdding })),
+    toggleIsEditing: () => set((state) => ({ isEditing: !state.isEditing })),
 
 }));
 export const useCards = () => useCardStore((state) => state.cards);
@@ -66,4 +69,6 @@ export const useAddCard = () => useCardStore((state) => state.addCard);
 export const useDeleteCard = () => useCardStore((state) => state.deleteCard);
 export const useUpdateCard = () => useCardStore((state) => state.updateCard);
 export const useIsAdding = () => useCardStore((state) => state.isAdding);
+export const useIsEditing = () => useCardStore((state) => state.isEditing)
 export const useToggleIsAdding = () => useCardStore((state) => state.toggleIsAdding);
+export const useToggleIsEditing = () => useCardStore((state) => state.toggleIsEditing);


### PR DESCRIPTION
Added an editing toggle to the card store to differentiate between editing and adding when using the modal. This stops the add modal from popping up once submitting an edit. 

Inadvertently used this branch to push these changes. Will use a new branch to add drawers